### PR TITLE
MIT Copyright Update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,7 @@
-Copyright (c) Roots Software LLC
+# MIT License
+
+Copyright (c) Roots Software LLC, 
+Copyright (c) 2025 Jasper Frumau
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This pull request updates the project license to clarify the terms and add a new copyright holder.

* License update:
  * [`LICENSE.md`](diffhunk://#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dL1-R4): Changed to the MIT License, and added Jasper Frumau as a copyright holder alongside Roots Software LLC.