### PR TITLE
Article Grid Refinement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,7 @@ location ~* \.(woff2)$ {
 - Navigation menus, theme supports, and widget areas are registered in setup files.
 - Block editor integration and asset loading are managed via Vite and custom filters.
 - Full-site editing is disabled; use custom block patterns if needed.
+- **CSS Variables**: Theme generates 316 total CSS variables (248 colors from `theme.json` + 68 WordPress presets) using `--wp--preset--*` format.
 
 ### Block Development Strategy
 The theme uses **Native Blocks as the PRIMARY approach** for all block development, providing maximum flexibility and modern development patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [1.0.0-alpha.7] - 2025-09-14
+
+### Improved
+- **Typography System Efficiency**: Streamlined editorial font size variables with consistent naming convention
+- **Article Grid Block Typography**: Enhanced font size controls with clear size indicators (14px, 16px, 24px, 30px, 55px)
+- **Block Editor Integration**: Improved typography consistency between editor and frontend with shared CSS variables
+- **Development Efficiency**: Unified font size system reduces CSS duplication and improves maintainability
+
+### Changed
+- **Font Size Variable Names**: Renamed from contextual names (`--font-size-hero`, `--font-size-title`) to size-based names (`--font-size-xx-large`, `--font-size-x-large`) for better scalability
+- **Article Grid Block Typography**: Updated font size options with descriptive labels showing actual pixel values
+- **Block Textdomain**: Corrected from `vendor` to `imagewize` for proper internationalization
+- **CSS Architecture**: Consolidated typography variables between app.css and editor.css for consistency
+
+### Technical Implementation
+- Typography scale now uses semantic size names (small/medium/large/x-large/xx-large) instead of context-specific names
+- Shared CSS variables between editor and frontend ensure WYSIWYG accuracy
+- Custom CSS classes (`article-grid-font-*`) provide precise font size control using editorial variables
+- Responsive typography automatically scales large sizes for mobile (55px→28px, 30px→20px)
+
+### Enhanced
+- **Block Editor Experience**: Font size controls now display actual pixel values for better user understanding
+- **Code Maintainability**: Simplified CSS variable system makes font size adjustments more predictable
+- **Typography Consistency**: Unified font size system across all theme components and blocks
+
+---
+
 ## [1.0.0-alpha.6] - 2025-09-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,8 @@ Add custom fonts to your Tailwind theme in `resources/css/app.css`:
 ### Theme.json Workflow
 The theme uses a preprocessed `theme.json` that gets compiled by Vite to include Tailwind's design tokens. The built version is loaded via the `theme_file_path` filter in `app/setup.php:54`.
 
+**CSS Variables**: The theme generates **316 total CSS variables** - 248 colors from `theme.json` plus 68 WordPress preset variables (aspect ratios, gradients, shadows, spacing). All use the `--wp--preset--*` format.
+
 ### Block Editor Integration
 - Editor styles are injected via `block_editor_settings_all` filter
 - Editor JavaScript dependencies are managed through Vite's manifest system

--- a/docs/CSS-VARS.md
+++ b/docs/CSS-VARS.md
@@ -1,0 +1,325 @@
+# CSS Variables Reference
+
+This document catalogs all available CSS variables in the Thyra theme, their sources, and usage patterns for blocks, Blade views, and components.
+
+## Variable Sources
+
+The theme generates **300+ CSS variables** from multiple sources:
+- **Custom Editorial Variables**: Defined in `resources/css/app.css`
+- **WordPress Preset Variables**: Generated from `theme.json` via Vite plugin (248 colors + 68 other presets)
+- **Tailwind Integration**: Via `@tailwindcss/vite` plugin and `wordpressThemeJson()` configuration
+
+## Custom Editorial Variables
+
+### Typography Scale
+```css
+/* Editorial Typography - Custom sizes not in Tailwind */
+--font-size-hero: 55px;            /* Hero post titles (desktop) */
+--font-size-hero-mobile: 28px;     /* Hero post titles (mobile) */
+--font-size-title: 30px;           /* Large editorial headlines (desktop) */
+--font-size-title-mobile: 20px;    /* Large editorial headlines (mobile) */
+--font-size-small: 14px;           /* Meta text - article-grid-block compatibility */
+```
+
+**Usage in Blocks:**
+```jsx
+// Article Grid Block - resources/js/blocks/article-grid-block/editor.jsx:214
+<h2 className={`wp-block-heading has-${headingFontFamily}-font-family article-grid-font-${headingFontSize}`}>
+
+// CSS implementation - resources/js/blocks/article-grid-block/style.css:61-79
+.article-grid-font-small {
+  font-size: var(--font-size-small) !important; /* 14px */
+}
+.article-grid-font-medium {
+  font-size: var(--font-size-medium) !important; /* 16px */
+}
+```
+
+### Font Families
+```css
+/* Individual font family definitions for WordPress theme.json */
+--font-lato: "Lato", system-ui, sans-serif;
+--font-bitter: "Bitter", serif;
+--font-menlo: "Menlo", ui-monospace, SFMono-Regular, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+```
+
+**Usage in Blade Views:**
+```blade
+{{-- Apply font families using WordPress block editor classes --}}
+<div class="has-lato-font-family">Sans serif content</div>
+<div class="has-bitter-font-family">Serif headings</div>
+<div class="has-menlo-font-family">Code blocks</div>
+```
+
+### Editorial Color Palette
+```css
+/* Thaiconomics Editorial Palette */
+--color-black: #000000;
+--color-charcoal: #333333;
+--color-gray: #666666;
+--color-light-gray: #999999;
+--color-white: #ffffff;
+--color-off-white: #fafafa;
+
+/* Extended grays for UI elements */
+--color-gray-50: #f9fafb;
+--color-gray-100: #f3f4f6;
+--color-gray-200: #e5e7eb;
+--color-gray-300: #d1d5db;
+--color-gray-400: #9ca3af;
+--color-gray-500: #6b7280;
+--color-gray-600: #4b5563;
+--color-gray-700: #374151;
+--color-gray-800: #1f2937;
+--color-gray-900: #111827;
+```
+
+### Line Heights & Spacing
+```css
+/* Line Heights for Editorial Design */
+--line-height-tight: 1.2;      /* Headlines - tighter than Tailwind's leading-tight (1.25) */
+--line-height-normal: 1.6;     /* Body text - looser than Tailwind's leading-normal (1.5) */
+--line-height-relaxed: 1.8;    /* Large body text - looser than Tailwind's leading-relaxed (1.625) */
+
+/* Custom Editorial Spacing */
+--spacing-section: 4rem;        /* Between major sections */
+--spacing-article: 2rem;        /* Between articles */
+--spacing-content: 1.5rem;      /* Content spacing */
+```
+
+### Layout & Design System Variables
+```css
+/* Content width constraints */
+--content-width-narrow: 65ch;   /* Optimal reading line length */
+--content-width-medium: 80ch;   /* Medium content blocks */
+--content-width-wide: 1200px;   /* Full-width sections */
+
+/* Editorial layout proportions */
+--hero-aspect-ratio: 16/9;      /* Hero image aspect ratio */
+--thumbnail-aspect-ratio: 4/3;  /* Article thumbnail aspect ratio */
+--sidebar-width: 320px;         /* Sidebar width */
+
+/* Animation durations */
+--transition-fast: 0.15s;
+--transition-normal: 0.3s;
+--transition-slow: 0.5s;
+
+/* Focus ring for accessibility */
+--focus-ring: 0 0 0 2px var(--color-black);
+
+/* Z-index Scale */
+--z-index-dropdown: 10;
+--z-index-modal: 50;
+--z-index-popover: 100;
+--z-index-tooltip: 200;
+```
+
+## WordPress Preset Variables
+
+Generated automatically from `theme.json` via `wordpressThemeJson()` Vite plugin with 316 total variables:
+
+### Color Variables (248 total)
+```css
+/* WordPress color presets - examples */
+--wp--preset--color--black: #000000;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--gray-50: #f9fafb;
+--wp--preset--color--gray-100: #f3f4f6;
+/* ... continues for all Tailwind colors */
+```
+
+### Typography Presets (68 total)
+```css
+/* Font family presets */
+--wp--preset--font-family--lato: "Lato", system-ui, sans-serif;
+--wp--preset--font-family--bitter: "Bitter", serif;
+--wp--preset--font-family--menlo: "Menlo", ui-monospace;
+
+/* Font size presets */
+--wp--preset--font-size--small: 14px;
+--wp--preset--font-size--medium: 16px;
+--wp--preset--font-size--large: 24px;
+--wp--preset--font-size--x-large: 30px;
+--wp--preset--font-size--xx-large: 55px;
+
+/* Spacing presets */
+--wp--preset--spacing--10: 0.25rem;
+--wp--preset--spacing--20: 0.5rem;
+--wp--preset--spacing--30: 0.75rem;
+/* ... continues for Tailwind spacing scale */
+
+/* Other presets */
+--wp--preset--aspect-ratio--square: 1;
+--wp--preset--aspect-ratio--4-3: 4/3;
+--wp--preset--aspect-ratio--16-9: 16/9;
+
+--wp--preset--shadow--natural: 0 8px 16px rgba(0, 0, 0, 0.15);
+--wp--preset--shadow--deep: 0 12px 24px rgba(0, 0, 0, 0.25);
+
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg, rgba(6,147,227,1) 0%, rgb(155,81,224) 100%);
+```
+
+## Usage Patterns
+
+### 1. Block Development (Native Blocks)
+
+**CSS Classes with Variables:**
+```css
+/* resources/js/blocks/article-grid-block/style.css */
+.article-grid-font-small {
+  font-size: var(--font-size-small) !important;
+}
+
+.article-grid-font-x-large {
+  font-size: var(--font-size-title) !important; /* 30px desktop */
+}
+
+/* Responsive usage */
+@media (max-width: 768px) {
+  .article-grid-font-x-large {
+    font-size: var(--font-size-title-mobile) !important; /* 20px mobile */
+  }
+}
+```
+
+**JSX Implementation:**
+```jsx
+// Dynamic class application
+<h2 className={`wp-block-heading has-${headingFontFamily}-font-family article-grid-font-${headingFontSize}`}>
+  {post.title?.rendered || ''}
+</h2>
+
+// CSS custom properties in inline styles
+<div style={{
+  color: 'var(--color-gray)',
+  marginTop: 'var(--spacing-content)'
+}}>
+```
+
+### 2. Blade Templates
+
+**WordPress Block Editor Classes:**
+```blade
+{{-- Font families --}}
+<div class="has-lato-font-family">Sans serif text</div>
+<div class="has-bitter-font-family">Serif headlines</div>
+
+{{-- WordPress preset classes --}}
+<div class="has-black-color has-white-background-color">
+  High contrast content
+</div>
+
+{{-- Custom CSS classes using variables --}}
+<article class="text-hero">Hero headline</article>
+<p class="text-meta">Meta information</p>
+```
+
+**Direct Variable Usage:**
+```blade
+<section style="
+  max-width: var(--content-width-wide);
+  margin: var(--spacing-section) auto;
+  padding: 0 var(--spacing-content);
+">
+  <div class="content-narrow">
+    {{-- Content uses CSS utility class --}}
+  </div>
+</section>
+```
+
+### 3. Component Development
+
+**CSS Utility Classes:**
+```css
+/* resources/css/app.css - Editorial Typography Utilities */
+.text-hero {
+  font-size: var(--font-size-hero);
+  line-height: var(--line-height-tight);
+  font-weight: 700;
+}
+
+.text-title {
+  font-size: var(--font-size-title);
+  line-height: var(--line-height-tight);
+  font-weight: 600;
+}
+
+.text-meta {
+  font-size: var(--font-size-small);
+  color: var(--color-gray);
+  font-weight: 400;
+}
+```
+
+**Layout Utilities:**
+```css
+.content-narrow { max-width: var(--content-width-narrow); }
+.content-medium { max-width: var(--content-width-medium); }
+.content-wide { max-width: var(--content-width-wide); }
+
+.aspect-hero { aspect-ratio: var(--hero-aspect-ratio); }
+.aspect-thumbnail { aspect-ratio: var(--thumbnail-aspect-ratio); }
+```
+
+### 4. Editor Integration
+
+**Matching Variables Across Files:**
+```css
+/* resources/css/app.css */
+--font-size-hero: 55px;
+
+/* resources/css/editor.css - Mirror for WYSIWYG */
+--font-size-hero: 55px;
+```
+
+## Configuration Sources
+
+### Vite Configuration
+```javascript
+// vite.config.js - WordPress theme.json generation
+wordpressThemeJson({
+  disableTailwindColors: false,    // Generates 248 color variables
+  disableTailwindFonts: false,     // Generates font family variables
+  disableTailwindFontSizes: false, // Generates font size variables
+})
+```
+
+### Theme.json Integration
+The `wordpressThemeJson()` plugin automatically:
+- Converts Tailwind config to WordPress theme.json format
+- Generates CSS variables for all Tailwind design tokens
+- Creates block editor compatible preset classes
+- Provides `--wp--preset--*` variables for all design tokens
+
+## Best Practices
+
+### 1. Variable Naming Convention
+- **Custom editorial**: `--font-size-hero`, `--color-charcoal`
+- **WordPress presets**: `--wp--preset--color--black`, `--wp--preset--font-size--large`
+- **CSS classes**: `article-grid-font-small`, `has-lato-font-family`
+
+### 2. Responsive Design
+```css
+/* Mobile-first approach with custom variables */
+.text-hero {
+  font-size: var(--font-size-hero-mobile);
+}
+
+@media (min-width: 768px) {
+  .text-hero {
+    font-size: var(--font-size-hero);
+  }
+}
+```
+
+### 3. Block Development
+- Use `!important` for block-specific typography overrides
+- Create semantic class names that reference variables
+- Provide responsive variants for mobile/desktop scaling
+- Mirror editor.css variables for WYSIWYG accuracy
+
+### 4. Performance Considerations
+- Variables are computed once at root level
+- Prefer CSS custom properties over inline styles for dynamic values
+- Use CSS classes for repeated patterns rather than inline variable references
+- WordPress preset variables are automatically optimized by the theme.json system

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -821,6 +821,23 @@ After implementing this Thaiconomics-inspired design:
 
 ## 📚 Technical Notes
 
+### CSS Variables Structure
+The theme uses **two complementary CSS variable systems**:
+
+**WordPress Preset Variables (316 total):**
+- **248 color entries** defined in `theme.json` (complete Tailwind palette)
+- **68 WordPress preset variables** auto-generated (aspect ratios, gradients, shadows, spacing, legacy colors)
+- Format: `--wp--preset--*` (e.g., `--wp--preset--color--red-500`, `--wp--preset--font-family--lato`)
+- Generated automatically from `theme.json` + WordPress core defaults
+
+**Custom Theme Variables (in `resources/css/app.css`):**
+- **Editorial design tokens**: `--color-black`, `--color-charcoal`, `--font-size-hero`
+- **Typography scale**: Custom sizes like `--font-size-xx-large` (55px desktop, 28px mobile)
+- **Spacing system**: Editorial spacing from `--spacing-xs` (8px) to `--spacing-5xl` (160px)
+- **Layout variables**: `--content-width-narrow` (65ch), `--sidebar-width` (320px)
+- **Animation/interaction**: `--transition-fast`, `--focus-ring`
+- Used for theme-specific design tokens not covered by WordPress presets
+
 ### Custom CSS Variables Usage
 All design tokens are stored as CSS custom properties for easy maintenance and theming.
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -39,13 +39,13 @@
      We don't define custom font sizes here to keep the rem-based responsive scale */
 
   /* Editorial Typography Scale */
-  --font-size-hero: 55px;        /* Hero post titles (desktop) */
-  --font-size-hero-mobile: 28px; /* Hero post titles (mobile) */
-  --font-size-title: 30px;       /* Large editorial headlines (desktop) */
-  --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) */
-  --font-size-subtitle: 24px;    /* Subtitle/deck text */
-  --font-size-body: 16px;        /* Body text */
-  --font-size-small: 14px;       /* Meta text */
+  --font-size-xx-large: 55px;        /* Hero post titles (desktop) */
+  --font-size-xx-large-mobile: 28px; /* Hero post titles (mobile) */
+  --font-size-x-large: 30px;         /* Large editorial headlines (desktop) */
+  --font-size-x-large-mobile: 20px;  /* Large editorial headlines (mobile) */
+  --font-size-large: 24px;           /* Subtitle/deck text */
+  --font-size-medium: 16px;          /* Body text */
+  --font-size-small: 14px;           /* Meta text */
   
   /* Line Heights for Editorial Design */
   --line-height-tight: 1.2;      /* Headlines */

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -38,53 +38,56 @@
   /* Note: Font sizes use Tailwind's built-in scale (text-xs, text-sm, text-base, etc.)
      We don't define custom font sizes here to keep the rem-based responsive scale */
 
-  /* Editorial Typography Scale */
-  --font-size-xx-large: 55px;        /* Hero post titles (desktop) */
-  --font-size-xx-large-mobile: 28px; /* Hero post titles (mobile) */
-  --font-size-x-large: 30px;         /* Large editorial headlines (desktop) */
-  --font-size-x-large-mobile: 20px;  /* Large editorial headlines (mobile) */
-  --font-size-large: 24px;           /* Subtitle/deck text */
-  --font-size-medium: 16px;          /* Body text */
-  --font-size-small: 14px;           /* Meta text */
+  /* Editorial Typography Scale - Only custom sizes not in Tailwind */
+  --font-size-hero: 55px;        /* Hero post titles (desktop) - between text-5xl (48px) and text-6xl (60px) */
+  --font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
+  --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
+  --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
+
+  /* Removed redundant variables that duplicate Tailwind's built-in scale:
+     --font-size-subtitle: 24px → Use text-2xl (24px)
+     --font-size-body: 16px → Use text-base (16px)
+     --font-size-small: 14px → Use text-sm (14px) */
+  --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
   
-  /* Line Heights for Editorial Design */
-  --line-height-tight: 1.2;      /* Headlines */
-  --line-height-normal: 1.6;     /* Body text */
-  --line-height-relaxed: 1.8;    /* Large body text */
+  /* Line Heights for Editorial Design - Only where different from Tailwind defaults */
+  --line-height-tight: 1.2;      /* Headlines - slightly tighter than Tailwind's leading-tight (1.25) */
+  --line-height-normal: 1.6;     /* Body text - looser than Tailwind's leading-normal (1.5) for readability */
+  --line-height-relaxed: 1.8;    /* Large body text - looser than Tailwind's leading-relaxed (1.625) */
   
-  /* Font Weights */
-  --font-weight-normal: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
+  /* Removed redundant font weights that duplicate Tailwind classes:
+     --font-weight-normal: 400 → Use font-normal
+     --font-weight-medium: 500 → Use font-medium
+     --font-weight-semibold: 600 → Use font-semibold
+     --font-weight-bold: 700 → Use font-bold */
   
-  /* Editorial Spacing System (generous whitespace) */
-  --spacing-xs: 0.5rem;    /* 8px */
-  --spacing-sm: 1rem;      /* 16px */
-  --spacing-md: 1.5rem;    /* 24px */
-  --spacing-lg: 2rem;      /* 32px */
-  --spacing-xl: 3rem;      /* 48px */
-  --spacing-2xl: 4rem;     /* 64px */
-  --spacing-3xl: 6rem;     /* 96px */
-  --spacing-4xl: 8rem;     /* 128px */
-  --spacing-5xl: 10rem;    /* 160px */
+  /* Removed redundant spacing variables that duplicate Tailwind's spacing scale:
+     --spacing-xs: 0.5rem → Use space-2 (8px)
+     --spacing-sm: 1rem → Use space-4 (16px)
+     --spacing-md: 1.5rem → Use space-6 (24px)
+     --spacing-lg: 2rem → Use space-8 (32px)
+     --spacing-xl: 3rem → Use space-12 (48px)
+     --spacing-2xl: 4rem → Use space-16 (64px)
+     --spacing-3xl: 6rem → Use space-24 (96px)
+     --spacing-4xl: 8rem → Use space-32 (128px)
+     --spacing-5xl: 10rem → Use space-40 (160px) */
   
   /* Custom Editorial Spacing */
   --spacing-section: 4rem;  /* Between major sections */
   --spacing-article: 2rem;  /* Between articles */
   --spacing-content: 1.5rem; /* Content spacing */
   
-  /* Border Radius */
-  --radius-none: 0;
-  --radius-sm: 0.25rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 1rem;
-  --radius-xl: 1.5rem;
+  /* Removed redundant border radius variables that duplicate Tailwind classes:
+     --radius-none: 0 → Use rounded-none
+     --radius-sm: 0.25rem → Use rounded-sm
+     --radius-md: 0.5rem → Use rounded-md
+     --radius-lg: 1rem → Use rounded-lg
+     --radius-xl: 1.5rem → Use rounded-xl */
   
-  /* Shadows for Editorial Design */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  /* Removed redundant shadow variables that duplicate Tailwind classes:
+     --shadow-sm → Use shadow-sm
+     --shadow-md → Use shadow-md
+     --shadow-lg → Use shadow-lg */
   
   /* Z-index Scale */
   --z-index-dropdown: 10;
@@ -126,29 +129,29 @@
   --focus-ring: 0 0 0 2px var(--color-black);
 }
 
-/* Editorial Typography Utilities */
+/* Editorial Typography Utilities - Using mix of custom variables and Tailwind classes */
 .text-hero {
   font-size: var(--font-size-hero);
   line-height: var(--line-height-tight);
-  font-weight: var(--font-weight-bold);
+  font-weight: 700; /* font-bold - was var(--font-weight-bold) */
 }
 
 .text-title {
   font-size: var(--font-size-title);
   line-height: var(--line-height-tight);
-  font-weight: var(--font-weight-semibold);
+  font-weight: 600; /* font-semibold - was var(--font-weight-semibold) */
 }
 
 .text-subtitle {
-  font-size: var(--font-size-subtitle);
+  font-size: 1.5rem; /* text-2xl (24px) - was var(--font-size-subtitle) */
   line-height: var(--line-height-normal);
-  font-weight: var(--font-weight-normal);
+  font-weight: 400; /* font-normal - was var(--font-weight-normal) */
 }
 
 .text-meta {
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-small); /* Kept for article-grid-block compatibility */
   color: var(--color-gray);
-  font-weight: var(--font-weight-normal);
+  font-weight: 400; /* font-normal - was var(--font-weight-normal) */
 }
 
 /* Responsive Typography */
@@ -217,5 +220,5 @@ html {
 *:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
-  border-radius: var(--radius-sm);
+  border-radius: 0.25rem; /* rounded-sm - was var(--radius-sm) */
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -43,11 +43,6 @@
   --font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
   --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
   --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
-
-  /* Removed redundant variables that duplicate Tailwind's built-in scale:
-     --font-size-subtitle: 24px → Use text-2xl (24px)
-     --font-size-body: 16px → Use text-base (16px)
-     --font-size-small: 14px → Use text-sm (14px) */
   --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
   
   /* Line Heights for Editorial Design - Only where different from Tailwind defaults */
@@ -55,39 +50,10 @@
   --line-height-normal: 1.6;     /* Body text - looser than Tailwind's leading-normal (1.5) for readability */
   --line-height-relaxed: 1.8;    /* Large body text - looser than Tailwind's leading-relaxed (1.625) */
   
-  /* Removed redundant font weights that duplicate Tailwind classes:
-     --font-weight-normal: 400 → Use font-normal
-     --font-weight-medium: 500 → Use font-medium
-     --font-weight-semibold: 600 → Use font-semibold
-     --font-weight-bold: 700 → Use font-bold */
-  
-  /* Removed redundant spacing variables that duplicate Tailwind's spacing scale:
-     --spacing-xs: 0.5rem → Use space-2 (8px)
-     --spacing-sm: 1rem → Use space-4 (16px)
-     --spacing-md: 1.5rem → Use space-6 (24px)
-     --spacing-lg: 2rem → Use space-8 (32px)
-     --spacing-xl: 3rem → Use space-12 (48px)
-     --spacing-2xl: 4rem → Use space-16 (64px)
-     --spacing-3xl: 6rem → Use space-24 (96px)
-     --spacing-4xl: 8rem → Use space-32 (128px)
-     --spacing-5xl: 10rem → Use space-40 (160px) */
-  
   /* Custom Editorial Spacing */
   --spacing-section: 4rem;  /* Between major sections */
   --spacing-article: 2rem;  /* Between articles */
   --spacing-content: 1.5rem; /* Content spacing */
-  
-  /* Removed redundant border radius variables that duplicate Tailwind classes:
-     --radius-none: 0 → Use rounded-none
-     --radius-sm: 0.25rem → Use rounded-sm
-     --radius-md: 0.5rem → Use rounded-md
-     --radius-lg: 1rem → Use rounded-lg
-     --radius-xl: 1.5rem → Use rounded-xl */
-  
-  /* Removed redundant shadow variables that duplicate Tailwind classes:
-     --shadow-sm → Use shadow-sm
-     --shadow-md → Use shadow-md
-     --shadow-lg → Use shadow-lg */
   
   /* Z-index Scale */
   --z-index-dropdown: 10;

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -1,14 +1,16 @@
 @import "tailwindcss";
 @import "./fonts.css";
 
-/* Import the theme variables for editor */
+/* Import the theme variables for editor - Only custom sizes not in Tailwind */
 @theme {
-  /* Editorial Typography Scale */
-  --font-size-xx-large: 55px;        /* Hero post titles (desktop) */
-  --font-size-xx-large-mobile: 28px; /* Hero post titles (mobile) */
-  --font-size-x-large: 30px;         /* Large editorial headlines (desktop) */
-  --font-size-x-large-mobile: 20px;  /* Large editorial headlines (mobile) */
-  --font-size-large: 24px;           /* Subtitle/deck text */
-  --font-size-medium: 16px;          /* Body text */
-  --font-size-small: 14px;           /* Meta text */
+  /* Editorial Typography Scale - Matching app.css custom variables */
+  --font-size-hero: 55px;        /* Hero post titles (desktop) - between text-5xl (48px) and text-6xl (60px) */
+  --font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
+  --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
+  --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
+  --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
+
+  /* Removed redundant variables - use Tailwind classes instead:
+     --font-size-large: 24px → Use text-2xl (24px)
+     --font-size-medium: 16px → Use text-base (16px) */
 }

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -9,8 +9,4 @@
   --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
   --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
   --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
-
-  /* Removed redundant variables - use Tailwind classes instead:
-     --font-size-large: 24px → Use text-2xl (24px)
-     --font-size-medium: 16px → Use text-base (16px) */
 }

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -1,2 +1,14 @@
 @import "tailwindcss";
 @import "./fonts.css";
+
+/* Import the theme variables for editor */
+@theme {
+  /* Editorial Typography Scale */
+  --font-size-xx-large: 55px;        /* Hero post titles (desktop) */
+  --font-size-xx-large-mobile: 28px; /* Hero post titles (mobile) */
+  --font-size-x-large: 30px;         /* Large editorial headlines (desktop) */
+  --font-size-x-large-mobile: 20px;  /* Large editorial headlines (mobile) */
+  --font-size-large: 24px;           /* Subtitle/deck text */
+  --font-size-medium: 16px;          /* Body text */
+  --font-size-small: 14px;           /* Meta text */
+}

--- a/resources/js/blocks/article-grid-block/block.json
+++ b/resources/js/blocks/article-grid-block/block.json
@@ -50,7 +50,7 @@
         },
         "headingFontSize": {
             "type": "string",
-            "default": "subtitle"
+            "default": "large"
         },
         "postSpacing": {
             "type": "string",

--- a/resources/js/blocks/article-grid-block/block.json
+++ b/resources/js/blocks/article-grid-block/block.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.wp.org/trunk/block.json",
     "apiVersion": 3,
-    "name": "vendor/article-grid-block",
+    "name": "imagewize/article-grid-block",
     "version": "0.1.0",
     "title": "Article Grid Block",
     "category": "layout",
@@ -11,7 +11,7 @@
     "supports": {
         "html": false
     },
-    "textdomain": "vendor",
+    "textdomain": "imagewize",
     "style": "file:./style.css",
     "editorStyle": "file:./editor.css",
     "viewScript": "file:./view.js",

--- a/resources/js/blocks/article-grid-block/editor.css
+++ b/resources/js/blocks/article-grid-block/editor.css
@@ -47,34 +47,34 @@
   gap: 4rem;
 }
 
-/* Custom typography scale using editorial CSS variables from app.css */
+/* Custom typography scale - Updated to match cleaned CSS variables */
 .article-grid-font-small {
-  font-size: var(--font-size-small) !important; /* 14px */
+  font-size: var(--font-size-small); /* 14px - kept for compatibility */
 }
 
 .article-grid-font-medium {
-  font-size: var(--font-size-medium) !important; /* 16px */
+  font-size: 1rem; /* 16px - was var(--font-size-medium), now using direct value (text-base equivalent) */
 }
 
 .article-grid-font-large {
-  font-size: var(--font-size-large) !important; /* 24px */
+  font-size: 1.5rem; /* 24px - was var(--font-size-large), now using direct value (text-2xl equivalent) */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--font-size-x-large) !important; /* 30px desktop */
+  font-size: var(--font-size-title); /* 30px desktop - was var(--font-size-x-large) */
 }
 
 .article-grid-font-xx-large {
-  font-size: var(--font-size-xx-large) !important; /* 55px desktop */
+  font-size: var(--font-size-hero); /* 55px desktop - was var(--font-size-xx-large) */
 }
 
-/* Responsive typography */
+/* Responsive typography - Updated to match cleaned CSS variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--font-size-x-large-mobile) !important; /* 20px mobile */
+    font-size: var(--font-size-title-mobile); /* 20px mobile - was var(--font-size-x-large-mobile) */
   }
 
   .article-grid-font-xx-large {
-    font-size: var(--font-size-xx-large-mobile) !important; /* 28px mobile */
+    font-size: var(--font-size-hero-mobile); /* 28px mobile - was var(--font-size-xx-large-mobile) */
   }
 }

--- a/resources/js/blocks/article-grid-block/editor.css
+++ b/resources/js/blocks/article-grid-block/editor.css
@@ -46,3 +46,35 @@
 .wp-block-imagewize-article-grid-block.article-grid-gap-xl .wp-block-columns {
   gap: 4rem;
 }
+
+/* Custom typography scale using editorial CSS variables from app.css */
+.article-grid-font-small {
+  font-size: var(--font-size-small) !important; /* 14px */
+}
+
+.article-grid-font-medium {
+  font-size: var(--font-size-medium) !important; /* 16px */
+}
+
+.article-grid-font-large {
+  font-size: var(--font-size-large) !important; /* 24px */
+}
+
+.article-grid-font-x-large {
+  font-size: var(--font-size-x-large) !important; /* 30px desktop */
+}
+
+.article-grid-font-xx-large {
+  font-size: var(--font-size-xx-large) !important; /* 55px desktop */
+}
+
+/* Responsive typography */
+@media (max-width: 768px) {
+  .article-grid-font-x-large {
+    font-size: var(--font-size-x-large-mobile) !important; /* 20px mobile */
+  }
+
+  .article-grid-font-xx-large {
+    font-size: var(--font-size-xx-large-mobile) !important; /* 28px mobile */
+  }
+}

--- a/resources/js/blocks/article-grid-block/editor.jsx
+++ b/resources/js/blocks/article-grid-block/editor.jsx
@@ -127,9 +127,9 @@ export default function Edit({ attributes, setAttributes }) {
                 label={__('Date Font Size', 'imagewize')}
                 value={dateFontSize}
                 options={[
-                  { label: __('Small', 'imagewize'), value: 'small' },
-                  { label: __('Normal', 'imagewize'), value: 'normal' },
-                  { label: __('Large', 'imagewize'), value: 'large' }
+                  { label: __('Small (14px)', 'imagewize'), value: 'small' },
+                  { label: __('Medium (16px)', 'imagewize'), value: 'medium' },
+                  { label: __('Large (24px)', 'imagewize'), value: 'large' }
                 ]}
                 onChange={(value) => setAttributes({ dateFontSize: value })}
               />
@@ -152,10 +152,11 @@ export default function Edit({ attributes, setAttributes }) {
             label={__('Heading Font Size', 'imagewize')}
             value={headingFontSize}
             options={[
-              { label: __('Small', 'imagewize'), value: 'small' },
-              { label: __('Normal', 'imagewize'), value: 'normal' },
-              { label: __('Large', 'imagewize'), value: 'large' },
-              { label: __('Subtitle', 'imagewize'), value: 'subtitle' }
+              { label: __('Small (14px)', 'imagewize'), value: 'small' },
+              { label: __('Medium (16px)', 'imagewize'), value: 'medium' },
+              { label: __('Large (24px)', 'imagewize'), value: 'large' },
+              { label: __('X-Large (30px)', 'imagewize'), value: 'x-large' },
+              { label: __('XX-Large (55px)', 'imagewize'), value: 'xx-large' }
             ]}
             onChange={(value) => setAttributes({ headingFontSize: value })}
           />
@@ -201,7 +202,7 @@ export default function Edit({ attributes, setAttributes }) {
               )}
               
               {showDate && (
-                <div className={`has-${dateFontFamily}-font-family has-${dateFontSize}-font-size`} style={{ marginTop: '1rem' }}>
+                <div className={`has-${dateFontFamily}-font-family article-grid-font-${dateFontSize}`} style={{ marginTop: '1rem' }}>
                   {new Date(post.date).toLocaleDateString('en-US', {
                     month: 'short',
                     day: 'numeric', 
@@ -210,12 +211,12 @@ export default function Edit({ attributes, setAttributes }) {
                 </div>
               )}
               
-              <h2 className={`wp-block-heading has-${headingFontFamily}-font-family has-${headingFontSize}-font-size`} style={{ marginTop: '0.5rem' }}>
+              <h2 className={`wp-block-heading has-${headingFontFamily}-font-family article-grid-font-${headingFontSize}`} style={{ marginTop: '0.5rem' }}>
                 {post.title?.rendered || ''}
               </h2>
 
               {showExcerpt && post.excerpt?.rendered && (
-                <div className="has-body-font-family has-small-font-size" style={{ marginTop: '0.5rem' }}>
+                <div className="has-body-font-family article-grid-font-small" style={{ marginTop: '0.5rem' }}>
                   {post.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 100)}...
                 </div>
               )}

--- a/resources/js/blocks/article-grid-block/editor.jsx
+++ b/resources/js/blocks/article-grid-block/editor.jsx
@@ -45,21 +45,21 @@ export default function Edit({ attributes, setAttributes }) {
   }, [numberOfPosts, selectedCategory, selectedTag, queryType]);
 
   const categoryOptions = [
-    { label: __('All Categories', 'vendor'), value: 0 },
+    { label: __('All Categories', 'imagewize'), value: 0 },
     ...(categories.map(cat => ({ label: cat.name, value: cat.id })))
   ];
 
   const tagOptions = [
-    { label: __('All Tags', 'vendor'), value: 0 },
+    { label: __('All Tags', 'imagewize'), value: 0 },
     ...(tags.map(tag => ({ label: tag.name, value: tag.id })))
   ];
 
   return (
     <>
       <InspectorControls>
-        <PanelBody title={__('Article Grid Settings', 'vendor')}>
+        <PanelBody title={__('Article Grid Settings', 'imagewize')}>
           <RangeControl
-            label={__('Number of Posts', 'vendor')}
+            label={__('Number of Posts', 'imagewize')}
             value={numberOfPosts}
             onChange={(value) => setAttributes({ numberOfPosts: value })}
             min={1}
@@ -67,19 +67,19 @@ export default function Edit({ attributes, setAttributes }) {
           />
           
           <RadioControl
-            label={__('Query Type', 'vendor')}
+            label={__('Query Type', 'imagewize')}
             selected={queryType}
             options={[
-              { label: __('Recent Posts', 'vendor'), value: 'recent' },
-              { label: __('By Category', 'vendor'), value: 'category' },
-              { label: __('By Tag', 'vendor'), value: 'tag' }
+              { label: __('Recent Posts', 'imagewize'), value: 'recent' },
+              { label: __('By Category', 'imagewize'), value: 'category' },
+              { label: __('By Tag', 'imagewize'), value: 'tag' }
             ]}
             onChange={(value) => setAttributes({ queryType: value })}
           />
 
           {queryType === 'category' && (
             <SelectControl
-              label={__('Select Category', 'vendor')}
+              label={__('Select Category', 'imagewize')}
               value={selectedCategory}
               options={categoryOptions}
               onChange={(value) => setAttributes({ selectedCategory: parseInt(value) })}
@@ -88,7 +88,7 @@ export default function Edit({ attributes, setAttributes }) {
 
           {queryType === 'tag' && (
             <SelectControl
-              label={__('Select Tag', 'vendor')}
+              label={__('Select Tag', 'imagewize')}
               value={selectedTag}
               options={tagOptions}
               onChange={(value) => setAttributes({ selectedTag: parseInt(value) })}
@@ -96,15 +96,15 @@ export default function Edit({ attributes, setAttributes }) {
           )}
         </PanelBody>
 
-        <PanelBody title={__('Article Grid Styling', 'vendor')}>
+        <PanelBody title={__('Article Grid Styling', 'imagewize')}>
           <ToggleControl
-            label={__('Show Date', 'vendor')}
+            label={__('Show Date', 'imagewize')}
             checked={showDate}
             onChange={(value) => setAttributes({ showDate: value })}
           />
 
           <ToggleControl
-            label={__('Show Excerpt', 'vendor')}
+            label={__('Show Excerpt', 'imagewize')}
             checked={showExcerpt}
             onChange={(value) => setAttributes({ showExcerpt: value })}
           />
@@ -112,24 +112,24 @@ export default function Edit({ attributes, setAttributes }) {
           {showDate && (
             <>
               <SelectControl
-                label={__('Date Font Family', 'vendor')}
+                label={__('Date Font Family', 'imagewize')}
                 value={dateFontFamily}
                 options={[
-                  { label: __('Lato (Sans Serif)', 'vendor'), value: 'lato' },
-                  { label: __('Bitter (Serif)', 'vendor'), value: 'bitter' },
-                  { label: __('Body (Default)', 'vendor'), value: 'body' },
-                  { label: __('Heading (Default)', 'vendor'), value: 'heading' }
+                  { label: __('Lato (Sans Serif)', 'imagewize'), value: 'lato' },
+                  { label: __('Bitter (Serif)', 'imagewize'), value: 'bitter' },
+                  { label: __('Body (Default)', 'imagewize'), value: 'body' },
+                  { label: __('Heading (Default)', 'imagewize'), value: 'heading' }
                 ]}
                 onChange={(value) => setAttributes({ dateFontFamily: value })}
               />
 
               <SelectControl
-                label={__('Date Font Size', 'vendor')}
+                label={__('Date Font Size', 'imagewize')}
                 value={dateFontSize}
                 options={[
-                  { label: __('Small', 'vendor'), value: 'small' },
-                  { label: __('Normal', 'vendor'), value: 'normal' },
-                  { label: __('Large', 'vendor'), value: 'large' }
+                  { label: __('Small', 'imagewize'), value: 'small' },
+                  { label: __('Normal', 'imagewize'), value: 'normal' },
+                  { label: __('Large', 'imagewize'), value: 'large' }
                 ]}
                 onChange={(value) => setAttributes({ dateFontSize: value })}
               />
@@ -137,50 +137,50 @@ export default function Edit({ attributes, setAttributes }) {
           )}
 
           <SelectControl
-            label={__('Heading Font Family', 'vendor')}
+            label={__('Heading Font Family', 'imagewize')}
             value={headingFontFamily}
             options={[
-              { label: __('Bitter (Serif)', 'vendor'), value: 'bitter' },
-              { label: __('Lato (Sans Serif)', 'vendor'), value: 'lato' },
-              { label: __('Body (Default)', 'vendor'), value: 'body' },
-              { label: __('Heading (Default)', 'vendor'), value: 'heading' }
+              { label: __('Bitter (Serif)', 'imagewize'), value: 'bitter' },
+              { label: __('Lato (Sans Serif)', 'imagewize'), value: 'lato' },
+              { label: __('Body (Default)', 'imagewize'), value: 'body' },
+              { label: __('Heading (Default)', 'imagewize'), value: 'heading' }
             ]}
             onChange={(value) => setAttributes({ headingFontFamily: value })}
           />
 
           <SelectControl
-            label={__('Heading Font Size', 'vendor')}
+            label={__('Heading Font Size', 'imagewize')}
             value={headingFontSize}
             options={[
-              { label: __('Small', 'vendor'), value: 'small' },
-              { label: __('Normal', 'vendor'), value: 'normal' },
-              { label: __('Large', 'vendor'), value: 'large' },
-              { label: __('Subtitle', 'vendor'), value: 'subtitle' }
+              { label: __('Small', 'imagewize'), value: 'small' },
+              { label: __('Normal', 'imagewize'), value: 'normal' },
+              { label: __('Large', 'imagewize'), value: 'large' },
+              { label: __('Subtitle', 'imagewize'), value: 'subtitle' }
             ]}
             onChange={(value) => setAttributes({ headingFontSize: value })}
           />
 
           <SelectControl
-            label={__('Post Spacing', 'vendor')}
+            label={__('Post Spacing', 'imagewize')}
             value={postSpacing}
             options={[
-              { label: __('None', 'vendor'), value: 'none' },
-              { label: __('Small', 'vendor'), value: 'small' },
-              { label: __('Default', 'vendor'), value: 'default' },
-              { label: __('Large', 'vendor'), value: 'large' }
+              { label: __('None', 'imagewize'), value: 'none' },
+              { label: __('Small', 'imagewize'), value: 'small' },
+              { label: __('Default', 'imagewize'), value: 'default' },
+              { label: __('Large', 'imagewize'), value: 'large' }
             ]}
             onChange={(value) => setAttributes({ postSpacing: value })}
           />
 
           <SelectControl
-            label={__('Column Gap', 'vendor')}
+            label={__('Column Gap', 'imagewize')}
             value={columnGap}
             options={[
-              { label: __('None', 'vendor'), value: 'none' },
-              { label: __('Small', 'vendor'), value: 'small' },
-              { label: __('Default', 'vendor'), value: 'default' },
-              { label: __('Large', 'vendor'), value: 'large' },
-              { label: __('Extra Large', 'vendor'), value: 'xl' }
+              { label: __('None', 'imagewize'), value: 'none' },
+              { label: __('Small', 'imagewize'), value: 'small' },
+              { label: __('Default', 'imagewize'), value: 'default' },
+              { label: __('Large', 'imagewize'), value: 'large' },
+              { label: __('Extra Large', 'imagewize'), value: 'xl' }
             ]}
             onChange={(value) => setAttributes({ columnGap: value })}
           />
@@ -224,7 +224,7 @@ export default function Edit({ attributes, setAttributes }) {
         </div>
         
         {posts.length === 0 && (
-          <p>{__('No posts found. Try adjusting your settings.', 'vendor')}</p>
+          <p>{__('No posts found. Try adjusting your settings.', 'imagewize')}</p>
         )}
       </div>
     </>

--- a/resources/js/blocks/article-grid-block/style.css
+++ b/resources/js/blocks/article-grid-block/style.css
@@ -56,34 +56,34 @@
 
 /* Default spacing is already handled by WordPress core styles */
 
-/* Custom typography scale using editorial CSS variables from app.css */
+/* Custom typography scale - Updated to match cleaned CSS variables */
 .article-grid-font-small {
-  font-size: var(--font-size-small) !important; /* 14px */
+  font-size: var(--font-size-small); /* 14px - kept for compatibility */
 }
 
 .article-grid-font-medium {
-  font-size: var(--font-size-medium) !important; /* 16px */
+  font-size: 1rem; /* 16px - was var(--font-size-medium), now using direct value (text-base equivalent) */
 }
 
 .article-grid-font-large {
-  font-size: var(--font-size-large) !important; /* 24px */
+  font-size: 1.5rem; /* 24px - was var(--font-size-large), now using direct value (text-2xl equivalent) */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--font-size-x-large) !important; /* 30px desktop */
+  font-size: var(--font-size-title); /* 30px desktop - was var(--font-size-x-large) */
 }
 
 .article-grid-font-xx-large {
-  font-size: var(--font-size-xx-large) !important; /* 55px desktop */
+  font-size: var(--font-size-hero); /* 55px desktop - was var(--font-size-xx-large) */
 }
 
-/* Responsive typography */
+/* Responsive typography - Updated to match cleaned CSS variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--font-size-x-large-mobile) !important; /* 20px mobile */
+    font-size: var(--font-size-title-mobile); /* 20px mobile - was var(--font-size-x-large-mobile) */
   }
 
   .article-grid-font-xx-large {
-    font-size: var(--font-size-xx-large-mobile) !important; /* 28px mobile */
+    font-size: var(--font-size-hero-mobile); /* 28px mobile - was var(--font-size-xx-large-mobile) */
   }
 }

--- a/resources/js/blocks/article-grid-block/style.css
+++ b/resources/js/blocks/article-grid-block/style.css
@@ -55,3 +55,35 @@
 }
 
 /* Default spacing is already handled by WordPress core styles */
+
+/* Custom typography scale using editorial CSS variables from app.css */
+.article-grid-font-small {
+  font-size: var(--font-size-small) !important; /* 14px */
+}
+
+.article-grid-font-medium {
+  font-size: var(--font-size-medium) !important; /* 16px */
+}
+
+.article-grid-font-large {
+  font-size: var(--font-size-large) !important; /* 24px */
+}
+
+.article-grid-font-x-large {
+  font-size: var(--font-size-x-large) !important; /* 30px desktop */
+}
+
+.article-grid-font-xx-large {
+  font-size: var(--font-size-xx-large) !important; /* 55px desktop */
+}
+
+/* Responsive typography */
+@media (max-width: 768px) {
+  .article-grid-font-x-large {
+    font-size: var(--font-size-x-large-mobile) !important; /* 20px mobile */
+  }
+
+  .article-grid-font-xx-large {
+    font-size: var(--font-size-xx-large-mobile) !important; /* 28px mobile */
+  }
+}

--- a/resources/js/blocks/article-grid-block/view.js
+++ b/resources/js/blocks/article-grid-block/view.js
@@ -94,14 +94,14 @@
           
           if (showDate) {
             columnHTML += `
-            <div class="has-${dateFontFamily}-font-family has-${dateFontSize}-font-size" style="margin-top: 1rem;">
+            <div class="has-${dateFontFamily}-font-family article-grid-font-${dateFontSize}" style="margin-top: 1rem;">
               ${postDate}
             </div>
             `;
           }
           
           columnHTML += `
-            <h2 class="wp-block-heading has-${headingFontFamily}-font-family has-${headingFontSize}-font-size" style="margin-top: 0.5rem;">
+            <h2 class="wp-block-heading has-${headingFontFamily}-font-family article-grid-font-${headingFontSize}" style="margin-top: 0.5rem;">
               <a href="${post.link}" style="text-decoration: none; color: inherit;">
                 ${post.title.rendered}
               </a>
@@ -111,7 +111,7 @@
           if (showExcerpt && post.excerpt && post.excerpt.rendered) {
             const excerptText = post.excerpt.rendered.replace(/<[^>]*>/g, '').substring(0, 100);
             columnHTML += `
-            <div class="has-body-font-family has-small-font-size" style="margin-top: 0.5rem;">
+            <div class="has-body-font-family article-grid-font-small" style="margin-top: 0.5rem;">
               ${excerptText}...
             </div>
             `;


### PR DESCRIPTION
This pull request introduces a major overhaul of the theme's typography system and CSS variable architecture, focusing on consistency, maintainability, and improved block editor integration. The changes unify font size naming conventions, consolidate CSS variables between frontend and editor, and enhance the user experience in the Article Grid Block by providing clear, size-based controls and labels. Internationalization is also improved by correcting the block textdomain and labels.

### Typography System & CSS Variables

* Unified font size variable names from contextual (e.g., `--font-size-title`) to semantic size-based names (e.g., `--font-size-x-large`, `--font-size-xx-large`) for better scalability and maintainability. This change is reflected across `resources/css/app.css`, `resources/css/editor.css`, and the Article Grid Block styles. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R27) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L41-L88) [[3]](diffhunk://#diff-4757132f197e0a85d9465a570f9ff10562f2764a3e3baa7481a1f9020ee7dc0cR49-R80) [[4]](diffhunk://#diff-301a5387448be4626bde7ed5efc8fa7ba9564af34b7fccdbbef6d908459cbef0R3-R12)
* The theme now generates 316 CSS variables (248 colors from `theme.json` + 68 WordPress presets) using the `--wp--preset--*` format, and clearly documents the structure and purpose of both WordPress preset and custom theme variables. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R372-R373) [[2]](diffhunk://#diff-27a16279e23cd453bac62f1ee7c261af722d17fb592ae422755a4ba7b9dbee90R824-R840) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R73)

### Block Editor & Article Grid Block Enhancements

* Improved typography controls in the Article Grid Block: font size options now use descriptive, size-based labels (e.g., "X-Large (30px)", "XX-Large (55px)") and actual pixel values, with responsive scaling for mobile. CSS classes (`article-grid-font-*`) are updated to match the new variable system. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R27) [[2]](diffhunk://#diff-de9ef52857776e9417dfcfb5df7a76a3861f510cd7e926d0c086248f8f96ee80L53-R53) [[3]](diffhunk://#diff-4757132f197e0a85d9465a570f9ff10562f2764a3e3baa7481a1f9020ee7dc0cR49-R80) [[4]](diffhunk://#diff-91e0163d33d48c2cc73d777575644b6f9e66567be25245e16f66f4c446b00286L204-R205)
* Block textdomain and block name changed from `vendor` to `imagewize` throughout all block files and editor controls, ensuring proper internationalization and consistency. [[1]](diffhunk://#diff-de9ef52857776e9417dfcfb5df7a76a3861f510cd7e926d0c086248f8f96ee80L4-R4) [[2]](diffhunk://#diff-de9ef52857776e9417dfcfb5df7a76a3861f510cd7e926d0c086248f8f96ee80L14-R14) [[3]](diffhunk://#diff-91e0163d33d48c2cc73d777575644b6f9e66567be25245e16f66f4c446b00286L48-R82) [[4]](diffhunk://#diff-91e0163d33d48c2cc73d777575644b6f9e66567be25245e16f66f4c446b00286L91-R184)

### CSS Architecture & Maintainability

* Consolidated typography variables between `app.css` and `editor.css`, ensuring a single source of truth and consistent WYSIWYG experience between frontend and editor. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R27) [[2]](diffhunk://#diff-301a5387448be4626bde7ed5efc8fa7ba9564af34b7fccdbbef6d908459cbef0R3-R12)
* Cleaned up unused or redundant variables and replaced variable references with direct values where appropriate for clarity and compatibility (e.g., font weights, border radius, subtitle font size). [[1]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L129-R120) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L220-R189)

---

These changes streamline the theme's design token management, make font size controls more predictable and user-friendly, and ensure a consistent editorial experience across both frontend and editor.