### PR TITLE
Typography Consolidation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,6 +72,25 @@ location ~* \.(woff2)$ {
 - Full-site editing is disabled; use custom block patterns if needed.
 - **CSS Variables**: Theme generates 316 total CSS variables (248 colors from `theme.json` + 68 WordPress presets) using `--wp--preset--*` format.
 
+#### ⚠️ Critical WordPress Preset Variable Naming Discovery
+
+**Important Finding**: WordPress preset variables use **dashes** in size names, not the format you might expect:
+
+```css
+/* ✅ CORRECT - WordPress generates variables with dashes */
+--wp--preset--font-size--2-xl    /* 24px - note the dash in "2-xl" */
+--wp--preset--font-size--3-xl    /* 30px - note the dash in "3-xl" */
+
+/* ❌ INCORRECT - This format does NOT exist */
+--wp--preset--font-size--2xl     /* Would expect this, but WordPress doesn't generate it */
+--wp--preset--font-size--3xl     /* Would expect this, but WordPress doesn't generate it */
+```
+
+**Build Process Requirement**:
+- WordPress preset variables are only available after `npm run build` (not `npm run dev`)
+- The `wordpressThemeJson()` Vite plugin processes `theme.json` during build phase
+- Development mode (`npm run dev`) does not generate these variables, so testing requires full build
+
 ### Block Development Strategy
 The theme uses **Native Blocks as the PRIMARY approach** for all block development, providing maximum flexibility and modern development patterns.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,25 @@ The theme uses a preprocessed `theme.json` that gets compiled by Vite to include
 
 **CSS Variables**: The theme generates **316 total CSS variables** - 248 colors from `theme.json` plus 68 WordPress preset variables (aspect ratios, gradients, shadows, spacing). All use the `--wp--preset--*` format.
 
+#### ⚠️ Critical WordPress Preset Variable Naming Discovery
+
+**Important Finding**: WordPress preset variables use **dashes** in size names, not the format you might expect:
+
+```css
+/* ✅ CORRECT - WordPress generates variables with dashes */
+--wp--preset--font-size--2-xl    /* 24px - note the dash in "2-xl" */
+--wp--preset--font-size--3-xl    /* 30px - note the dash in "3-xl" */
+
+/* ❌ INCORRECT - This format does NOT exist */
+--wp--preset--font-size--2xl     /* Would expect this, but WordPress doesn't generate it */
+--wp--preset--font-size--3xl     /* Would expect this, but WordPress doesn't generate it */
+```
+
+**Build Process Requirement**:
+- WordPress preset variables are only available after `npm run build` (not `npm run dev`)
+- The `wordpressThemeJson()` Vite plugin processes `theme.json` during build phase
+- Development mode (`npm run dev`) does not generate these variables, so testing requires full build
+
 ### Block Editor Integration
 - Editor styles are injected via `block_editor_settings_all` filter
 - Editor JavaScript dependencies are managed through Vite's manifest system

--- a/docs/CSS-VARS.md
+++ b/docs/CSS-VARS.md
@@ -18,7 +18,7 @@ This document catalogs all available CSS variables in the Thyra theme, their sou
     - [Font Size Variables (13 total)](#font-size-variables-13-total)
   - [Other WordPress Presets](#other-wordpress-presets)
 - [Complete Font Size Reference](#complete-font-size-reference)
-  - [Custom Editorial Font Sizes (5 total)](#custom-editorial-font-sizes-5-total)
+  - [Custom Editorial Font Sizes (2 total)](#custom-editorial-font-sizes-2-total)
   - [Tailwind Generated Font Sizes (13 total)](#tailwind-generated-font-sizes-13-total)
 - [Usage Patterns](#usage-patterns)
   - [1. Block Development (Native Blocks)](#1-block-development-native-blocks)
@@ -229,21 +229,23 @@ Generated automatically from `theme.json` via `wordpressThemeJson()` Vite plugin
 
 ## Complete Font Size Reference
 
-The theme provides **18 total font size variables** from two sources, offering comprehensive typography control for all design needs.
+The theme provides **15 total font size variables** from two sources, offering comprehensive typography control for all design needs.
 
-### Custom Editorial Font Sizes (5 total)
-These are custom sizes specific to editorial design, defined in `resources/css/app.css`:
+### Custom Editorial Font Sizes (2 total)
+These are unique sizes specific to editorial design, defined in `resources/css/app.css`:
 
 ```css
-/* Editorial Typography - Custom sizes not in Tailwind */
---font-size-hero: 55px;            /* Hero post titles (desktop) */
---font-size-hero-mobile: 28px;     /* Hero post titles (mobile) */
---font-size-title: 30px;           /* Large editorial headlines (desktop) */
---font-size-title-mobile: 20px;    /* Large editorial headlines (mobile) */
---font-size-small: 14px;           /* Meta text - article-grid-block compatibility */
+/* Editorial Typography - Only unique sizes not in Tailwind */
+--font-size-hero: 55px;        /* Hero post titles (desktop) - between text-5xl (48px) and text-6xl (60px) */
+--font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
+
+/* Note: Consolidated font sizes to use Tailwind presets:
+   - --font-size-small (14px) → use --wp--preset--font-size--sm
+   - --font-size-title (30px) → use --wp--preset--font-size--3xl
+   - --font-size-title-mobile (20px) → use --wp--preset--font-size--xl */
 ```
 
-**Usage:** Primarily in custom blocks and editorial templates where specific design requirements need precise control.
+**Usage:** Unique editorial hero sizes that fall between Tailwind's standard scale for precise editorial impact.
 
 ### Tailwind Generated Font Sizes (13 total)
 WordPress preset variables generated from Tailwind's font size scale via `wordpressThemeJson()`:
@@ -304,16 +306,16 @@ WordPress preset variables generated from Tailwind's font size scale via `wordpr
 **Size Comparison Chart:**
 ```
  12px  --wp--preset--font-size--xs
- 14px  --wp--preset--font-size--sm  ≈ --font-size-small
+ 14px  --wp--preset--font-size--sm      (replaces --font-size-small)
  16px  --wp--preset--font-size--base
  18px  --wp--preset--font-size--lg
- 20px  --wp--preset--font-size--xl   ≈ --font-size-title-mobile
+ 20px  --wp--preset--font-size--xl      (replaces --font-size-title-mobile)
  24px  --wp--preset--font-size--2xl
- 28px  --font-size-hero-mobile
- 30px  --wp--preset--font-size--3xl  ≈ --font-size-title
+ 28px  --font-size-hero-mobile          (unique editorial size)
+ 30px  --wp--preset--font-size--3xl     (replaces --font-size-title)
  36px  --wp--preset--font-size--4xl
  48px  --wp--preset--font-size--5xl
- 55px  --font-size-hero
+ 55px  --font-size-hero                 (unique editorial size)
  60px  --wp--preset--font-size--6xl
  72px  --wp--preset--font-size--7xl
  96px  --wp--preset--font-size--8xl

--- a/docs/CSS-VARS.md
+++ b/docs/CSS-VARS.md
@@ -330,17 +330,21 @@ WordPress preset variables generated from Tailwind's font size scale via `wordpr
 ```css
 /* resources/js/blocks/article-grid-block/style.css */
 .article-grid-font-small {
-  font-size: var(--font-size-small) !important;
+  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - WordPress preset with dash */
+}
+
+.article-grid-font-large {
+  font-size: var(--wp--preset--font-size--2-xl) !important; /* 24px - WordPress preset with dash */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--font-size-title) !important; /* 30px desktop */
+  font-size: var(--wp--preset--font-size--3-xl) !important; /* 30px desktop - WordPress preset with dash */
 }
 
 /* Responsive usage */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--font-size-title-mobile) !important; /* 20px mobile */
+    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - WordPress preset */
   }
 }
 ```
@@ -402,13 +406,13 @@ WordPress preset variables generated from Tailwind's font size scale via `wordpr
 }
 
 .text-title {
-  font-size: var(--font-size-title);
+  font-size: var(--wp--preset--font-size--3-xl); /* 30px - WordPress preset with dash */
   line-height: var(--line-height-tight);
   font-weight: 600;
 }
 
 .text-meta {
-  font-size: var(--font-size-small);
+  font-size: var(--wp--preset--font-size--sm); /* 14px - WordPress preset with dash */
   color: var(--color-gray);
   font-weight: 400;
 }
@@ -453,6 +457,30 @@ The `wordpressThemeJson()` plugin automatically:
 - Generates CSS variables for all Tailwind design tokens
 - Creates block editor compatible preset classes
 - Provides `--wp--preset--*` variables for all design tokens
+
+### ⚠️ Important Discovery: WordPress Preset Variable Naming
+
+**Critical Finding**: WordPress preset variables use **dashes** in size names, not the expected format:
+
+```css
+/* ✅ CORRECT - WordPress generates variables with dashes */
+--wp--preset--font-size--2-xl    /* 24px - note the dash in "2-xl" */
+--wp--preset--font-size--3-xl    /* 30px - note the dash in "3-xl" */
+
+/* ❌ INCORRECT - This format does NOT exist */
+--wp--preset--font-size--2xl     /* Would expect this, but WordPress doesn't generate it */
+--wp--preset--font-size--3xl     /* Would expect this, but WordPress doesn't generate it */
+```
+
+**Build Process Requirement**:
+- WordPress preset variables are only available after `npm run build` (not `npm run dev`)
+- The `wordpressThemeJson()` Vite plugin processes `theme.json` during build phase
+- Development mode (`npm run dev`) does not generate these variables
+
+**Resolution**: All font size implementations have been updated to use the correct dash convention throughout:
+- `/resources/js/blocks/article-grid-block/style.css`
+- `/resources/js/blocks/article-grid-block/editor.css`
+- `/resources/css/app.css`
 
 ## Best Practices
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -105,19 +105,19 @@
 }
 
 .text-title {
-  font-size: var(--wp--preset--font-size--3xl); /* 30px - was var(--font-size-title) */
+  font-size: var(--wp--preset--font-size--3-xl); /* 30px - WordPress preset with dash */
   line-height: var(--line-height-tight);
   font-weight: 600; /* font-semibold - was var(--font-weight-semibold) */
 }
 
 .text-subtitle {
-  font-size: 1.5rem; /* text-2xl (24px) - was var(--font-size-subtitle) */
+  font-size: var(--wp--preset--font-size--2-xl); /* 24px - WordPress preset with dash */
   line-height: var(--line-height-normal);
   font-weight: 400; /* font-normal - was var(--font-weight-normal) */
 }
 
 .text-meta {
-  font-size: var(--wp--preset--font-size--sm); /* 14px - was var(--font-size-small) */
+  font-size: var(--wp--preset--font-size--sm); /* 14px - WordPress preset with dash */
   color: var(--color-gray);
   font-weight: 400; /* font-normal - was var(--font-weight-normal) */
 }
@@ -129,7 +129,7 @@
   }
   
   .text-title {
-    font-size: var(--wp--preset--font-size--xl); /* 20px - was var(--font-size-title-mobile) */
+    font-size: var(--wp--preset--font-size--xl); /* 20px - WordPress preset */
   }
 }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -38,12 +38,14 @@
   /* Note: Font sizes use Tailwind's built-in scale (text-xs, text-sm, text-base, etc.)
      We don't define custom font sizes here to keep the rem-based responsive scale */
 
-  /* Editorial Typography Scale - Only custom sizes not in Tailwind */
+  /* Editorial Typography Scale - Only unique sizes not in Tailwind */
   --font-size-hero: 55px;        /* Hero post titles (desktop) - between text-5xl (48px) and text-6xl (60px) */
   --font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
-  --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
-  --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
-  --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
+
+  /* Note: Consolidated font sizes to use Tailwind presets:
+     - --font-size-small (14px) → use --wp--preset--font-size--sm
+     - --font-size-title (30px) → use --wp--preset--font-size--3xl
+     - --font-size-title-mobile (20px) → use --wp--preset--font-size--xl */
   
   /* Line Heights for Editorial Design - Only where different from Tailwind defaults */
   --line-height-tight: 1.2;      /* Headlines - slightly tighter than Tailwind's leading-tight (1.25) */
@@ -103,7 +105,7 @@
 }
 
 .text-title {
-  font-size: var(--font-size-title);
+  font-size: var(--wp--preset--font-size--3xl); /* 30px - was var(--font-size-title) */
   line-height: var(--line-height-tight);
   font-weight: 600; /* font-semibold - was var(--font-weight-semibold) */
 }
@@ -115,7 +117,7 @@
 }
 
 .text-meta {
-  font-size: var(--font-size-small); /* Kept for article-grid-block compatibility */
+  font-size: var(--wp--preset--font-size--sm); /* 14px - was var(--font-size-small) */
   color: var(--color-gray);
   font-weight: 400; /* font-normal - was var(--font-weight-normal) */
 }
@@ -127,7 +129,7 @@
   }
   
   .text-title {
-    font-size: var(--font-size-title-mobile);
+    font-size: var(--wp--preset--font-size--xl); /* 20px - was var(--font-size-title-mobile) */
   }
 }
 

--- a/resources/css/editor.css
+++ b/resources/css/editor.css
@@ -1,12 +1,14 @@
 @import "tailwindcss";
 @import "./fonts.css";
 
-/* Import the theme variables for editor - Only custom sizes not in Tailwind */
+/* Import the theme variables for editor - Only unique sizes not in Tailwind */
 @theme {
-  /* Editorial Typography Scale - Matching app.css custom variables */
+  /* Editorial Typography Scale - Matching app.css unique variables */
   --font-size-hero: 55px;        /* Hero post titles (desktop) - between text-5xl (48px) and text-6xl (60px) */
   --font-size-hero-mobile: 28px; /* Hero post titles (mobile) - between text-xl (20px) and text-2xl (24px) */
-  --font-size-title: 30px;       /* Large editorial headlines (desktop) - between text-2xl (24px) and text-3xl (30px) */
-  --font-size-title-mobile: 20px; /* Large editorial headlines (mobile) - same as text-xl but explicit for editorial */
-  --font-size-small: 14px;       /* Meta text - kept for article-grid-block compatibility */
+
+  /* Note: Consolidated font sizes to use Tailwind presets:
+     - --font-size-small (14px) → use --wp--preset--font-size--sm
+     - --font-size-title (30px) → use --wp--preset--font-size--3xl
+     - --font-size-title-mobile (20px) → use --wp--preset--font-size--xl */
 }

--- a/resources/js/blocks/article-grid-block/editor.css
+++ b/resources/js/blocks/article-grid-block/editor.css
@@ -47,21 +47,21 @@
   gap: 4rem;
 }
 
-/* Custom typography scale - Using WordPress preset variables */
+/* Custom typography scale - Using WordPress preset variables (requires npm run build) */
 .article-grid-font-small {
-  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - now using Tailwind preset */
+  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - WordPress preset with dash */
 }
 
 .article-grid-font-medium {
-  font-size: var(--wp--preset--font-size--base) !important; /* 16px - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--base) !important; /* 16px - WordPress preset */
 }
 
 .article-grid-font-large {
-  font-size: var(--wp--preset--font-size--2xl) !important; /* 24px - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--2-xl) !important; /* 24px - WordPress preset with dash */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--wp--preset--font-size--3xl) !important; /* 30px desktop - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--3-xl) !important; /* 30px desktop - WordPress preset with dash */
 }
 
 .article-grid-font-xx-large {
@@ -71,7 +71,7 @@
 /* Responsive typography - Using WordPress preset variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - using Tailwind preset */
+    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - WordPress preset */
   }
 
   .article-grid-font-xx-large {

--- a/resources/js/blocks/article-grid-block/editor.css
+++ b/resources/js/blocks/article-grid-block/editor.css
@@ -47,34 +47,34 @@
   gap: 4rem;
 }
 
-/* Custom typography scale - Updated to match cleaned CSS variables */
+/* Custom typography scale - Using WordPress preset variables */
 .article-grid-font-small {
-  font-size: var(--font-size-small); /* 14px - kept for compatibility */
+  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - now using Tailwind preset */
 }
 
 .article-grid-font-medium {
-  font-size: 1rem; /* 16px - was var(--font-size-medium), now using direct value (text-base equivalent) */
+  font-size: var(--wp--preset--font-size--base) !important; /* 16px - using Tailwind preset */
 }
 
 .article-grid-font-large {
-  font-size: 1.5rem; /* 24px - was var(--font-size-large), now using direct value (text-2xl equivalent) */
+  font-size: var(--wp--preset--font-size--2xl) !important; /* 24px - using Tailwind preset */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--font-size-title); /* 30px desktop - was var(--font-size-x-large) */
+  font-size: var(--wp--preset--font-size--3xl) !important; /* 30px desktop - using Tailwind preset */
 }
 
 .article-grid-font-xx-large {
-  font-size: var(--font-size-hero); /* 55px desktop - was var(--font-size-xx-large) */
+  font-size: var(--font-size-hero) !important; /* 55px desktop - unique editorial size */
 }
 
-/* Responsive typography - Updated to match cleaned CSS variables */
+/* Responsive typography - Using WordPress preset variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--font-size-title-mobile); /* 20px mobile - was var(--font-size-x-large-mobile) */
+    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - using Tailwind preset */
   }
 
   .article-grid-font-xx-large {
-    font-size: var(--font-size-hero-mobile); /* 28px mobile - was var(--font-size-xx-large-mobile) */
+    font-size: var(--font-size-hero-mobile) !important; /* 28px mobile - unique editorial size */
   }
 }

--- a/resources/js/blocks/article-grid-block/editor.jsx
+++ b/resources/js/blocks/article-grid-block/editor.jsx
@@ -127,9 +127,9 @@ export default function Edit({ attributes, setAttributes }) {
                 label={__('Date Font Size', 'imagewize')}
                 value={dateFontSize}
                 options={[
-                  { label: __('Small (14px)', 'imagewize'), value: 'small' },
-                  { label: __('Medium (16px)', 'imagewize'), value: 'medium' },
-                  { label: __('Large (24px)', 'imagewize'), value: 'large' }
+                  { label: __('Small (14px - Tailwind sm)', 'imagewize'), value: 'small' },
+                  { label: __('Medium (16px - Tailwind base)', 'imagewize'), value: 'medium' },
+                  { label: __('Large (24px - Tailwind 2xl)', 'imagewize'), value: 'large' }
                 ]}
                 onChange={(value) => setAttributes({ dateFontSize: value })}
               />
@@ -152,11 +152,11 @@ export default function Edit({ attributes, setAttributes }) {
             label={__('Heading Font Size', 'imagewize')}
             value={headingFontSize}
             options={[
-              { label: __('Small (14px)', 'imagewize'), value: 'small' },
-              { label: __('Medium (16px)', 'imagewize'), value: 'medium' },
-              { label: __('Large (24px)', 'imagewize'), value: 'large' },
-              { label: __('X-Large (30px)', 'imagewize'), value: 'x-large' },
-              { label: __('XX-Large (55px)', 'imagewize'), value: 'xx-large' }
+              { label: __('Small (14px - Tailwind sm)', 'imagewize'), value: 'small' },
+              { label: __('Medium (16px - Tailwind base)', 'imagewize'), value: 'medium' },
+              { label: __('Large (24px - Tailwind 2xl)', 'imagewize'), value: 'large' },
+              { label: __('X-Large (30px - Tailwind 3xl)', 'imagewize'), value: 'x-large' },
+              { label: __('XX-Large (55px - Editorial)', 'imagewize'), value: 'xx-large' }
             ]}
             onChange={(value) => setAttributes({ headingFontSize: value })}
           />

--- a/resources/js/blocks/article-grid-block/style.css
+++ b/resources/js/blocks/article-grid-block/style.css
@@ -56,21 +56,21 @@
 
 /* Default spacing is already handled by WordPress core styles */
 
-/* Custom typography scale - Using WordPress preset variables */
+/* Custom typography scale - Using WordPress preset variables (requires npm run build) */
 .article-grid-font-small {
-  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - now using Tailwind preset */
+  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - WordPress preset with dash */
 }
 
 .article-grid-font-medium {
-  font-size: var(--wp--preset--font-size--base) !important; /* 16px - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--base) !important; /* 16px - WordPress preset */
 }
 
 .article-grid-font-large {
-  font-size: var(--wp--preset--font-size--2xl) !important; /* 24px - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--2-xl) !important; /* 24px - WordPress preset with dash */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--wp--preset--font-size--3xl) !important; /* 30px desktop - using Tailwind preset */
+  font-size: var(--wp--preset--font-size--3-xl) !important; /* 30px desktop - WordPress preset with dash */
 }
 
 .article-grid-font-xx-large {
@@ -80,7 +80,7 @@
 /* Responsive typography - Using WordPress preset variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - using Tailwind preset */
+    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - WordPress preset */
   }
 
   .article-grid-font-xx-large {

--- a/resources/js/blocks/article-grid-block/style.css
+++ b/resources/js/blocks/article-grid-block/style.css
@@ -56,34 +56,34 @@
 
 /* Default spacing is already handled by WordPress core styles */
 
-/* Custom typography scale - Updated to match cleaned CSS variables */
+/* Custom typography scale - Using WordPress preset variables */
 .article-grid-font-small {
-  font-size: var(--font-size-small); /* 14px - kept for compatibility */
+  font-size: var(--wp--preset--font-size--sm) !important; /* 14px - now using Tailwind preset */
 }
 
 .article-grid-font-medium {
-  font-size: 1rem; /* 16px - was var(--font-size-medium), now using direct value (text-base equivalent) */
+  font-size: var(--wp--preset--font-size--base) !important; /* 16px - using Tailwind preset */
 }
 
 .article-grid-font-large {
-  font-size: 1.5rem; /* 24px - was var(--font-size-large), now using direct value (text-2xl equivalent) */
+  font-size: var(--wp--preset--font-size--2xl) !important; /* 24px - using Tailwind preset */
 }
 
 .article-grid-font-x-large {
-  font-size: var(--font-size-title); /* 30px desktop - was var(--font-size-x-large) */
+  font-size: var(--wp--preset--font-size--3xl) !important; /* 30px desktop - using Tailwind preset */
 }
 
 .article-grid-font-xx-large {
-  font-size: var(--font-size-hero); /* 55px desktop - was var(--font-size-xx-large) */
+  font-size: var(--font-size-hero) !important; /* 55px desktop - unique editorial size */
 }
 
-/* Responsive typography - Updated to match cleaned CSS variables */
+/* Responsive typography - Using WordPress preset variables */
 @media (max-width: 768px) {
   .article-grid-font-x-large {
-    font-size: var(--font-size-title-mobile); /* 20px mobile - was var(--font-size-x-large-mobile) */
+    font-size: var(--wp--preset--font-size--xl) !important; /* 20px mobile - using Tailwind preset */
   }
 
   .article-grid-font-xx-large {
-    font-size: var(--font-size-hero-mobile); /* 28px mobile - was var(--font-size-xx-large-mobile) */
+    font-size: var(--font-size-hero-mobile) !important; /* 28px mobile - unique editorial size */
   }
 }


### PR DESCRIPTION
This pull request standardizes font size variable usage across the theme by switching from custom CSS variables to WordPress preset variables with the correct dash-based naming convention. It also consolidates editorial font sizes, updates documentation, and ensures all styles and block options reference the new variable format. These changes improve consistency, maintainability, and compatibility with WordPress's build process.

**Font Size Variable Standardization**

* Replaced custom font size variables (e.g., `--font-size-title`, `--font-size-small`) with WordPress preset variables using dash notation (e.g., `--wp--preset--font-size--3-xl`, `--wp--preset--font-size--sm`) throughout all CSS files, including `resources/css/app.css`, `resources/css/editor.css`, `resources/js/blocks/article-grid-block/style.css`, and `resources/js/blocks/article-grid-block/editor.css`. [[1]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L106-R120) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L130-R132) [[3]](diffhunk://#diff-4757132f197e0a85d9465a570f9ff10562f2764a3e3baa7481a1f9020ee7dc0cL50-R78) [[4]](diffhunk://#diff-54de5d5409cdfe82a2af7de720826cf88f10460d048921c0d94f7e6a7869a78bL59-R87)
* Updated responsive and block-specific styles to use the correct preset variables for all font size options, ensuring compatibility with the WordPress build process. [[1]](diffhunk://#diff-4757132f197e0a85d9465a570f9ff10562f2764a3e3baa7481a1f9020ee7dc0cL50-R78) [[2]](diffhunk://#diff-54de5d5409cdfe82a2af7de720826cf88f10460d048921c0d94f7e6a7869a78bL59-R87)

**Editorial Font Size Consolidation**

* Reduced the number of custom editorial font size variables from five to two (`--font-size-hero`, `--font-size-hero-mobile`), consolidating others to use Tailwind/WordPress presets. Updated documentation and CSS comments to reflect this change. [[1]](diffhunk://#diff-21edfc234f0cf9eba47756c77b12fc9c069eb02c3b3c65523aaaad6628b1e585L232-R248) [[2]](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998L41-R48) [[3]](diffhunk://#diff-301a5387448be4626bde7ed5efc8fa7ba9564af34b7fccdbbef6d908459cbef0L4-R13)

**Documentation Updates**

* Added clear documentation in `.github/copilot-instructions.md`, `CLAUDE.md`, and `docs/CSS-VARS.md` about the dash-based naming convention for WordPress preset variables, the build process requirement, and the resolution steps. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R75-R93) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R374-R392) [[3]](diffhunk://#diff-21edfc234f0cf9eba47756c77b12fc9c069eb02c3b3c65523aaaad6628b1e585R461-R484)
* Updated font size reference tables, usage examples, and code snippets in documentation to use the new variable names and conventions. [[1]](diffhunk://#diff-21edfc234f0cf9eba47756c77b12fc9c069eb02c3b3c65523aaaad6628b1e585L307-R318) [[2]](diffhunk://#diff-21edfc234f0cf9eba47756c77b12fc9c069eb02c3b3c65523aaaad6628b1e585L331-R347) [[3]](diffhunk://#diff-21edfc234f0cf9eba47756c77b12fc9c069eb02c3b3c65523aaaad6628b1e585L403-R415)

**Block Editor Option Improvements**

* Updated block editor font size dropdown labels in `resources/js/blocks/article-grid-block/editor.jsx` to clarify which Tailwind/WordPress preset each option maps to, improving usability and clarity for editors. [[1]](diffhunk://#diff-91e0163d33d48c2cc73d777575644b6f9e66567be25245e16f66f4c446b00286L130-R132) [[2]](diffhunk://#diff-91e0163d33d48c2cc73d777575644b6f9e66567be25245e16f66f4c446b00286L155-R159)

**Navigation and Reference Fixes**

* Adjusted documentation navigation and section counts to reflect the reduced number of custom editorial font sizes.

Let me know if you have questions about how to use the new preset variables or how this impacts your block development workflow!